### PR TITLE
feat: add optional reused frame callbacks for zero-copy observers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ CURRENT_PATH=$(shell pwd)
 UNAME_S := $(shell uname -s)
 OS := unknown
 BASIC_EXAMPLES := send_recv_pcm send_recv_yuv recv_h264 recv_pcm_loopback sample_vad send_recv_yuv_pcm ai_send_recv_pcm
-BASIC_EXAMPLES =  send_recv_pcm send_recv_yuv recv_h264 recv_pcm_loopback sample_vad send_recv_yuv_pcm ai_send_recv_pcm example_externalaudio_processor
+BASIC_EXAMPLES =  send_recv_pcm send_recv_yuv send_recv_yuv_reused recv_h264 recv_h264_reused recv_pcm_loopback recv_pcm_reused sample_vad send_recv_yuv_pcm ai_send_recv_pcm example_externalaudio_processor
 ADVANCED_EXAMPLES := multi_cons_rtx send_encoded_audio send_h264 send_mp4 example_h264_decode
 ADVANCED_EXAMPLES =  send_encoded_audio send_h264 send_mp4 multi_cons_rtx example_h264_decode
 

--- a/go_sdk/examples/recv_h264_reused/recv_h264_reused.go
+++ b/go_sdk/examples/recv_h264_reused/recv_h264_reused.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"sync"
+	"time"
+
+	agoraservice "github.com/AgoraIO-Extensions/Agora-Golang-Server-SDK/v2/go_sdk/rtc"
+	rtctokenbuilder "github.com/AgoraIO/Tools/DynamicKey/AgoraDynamicKey/go/src/rtctokenbuilder2"
+)
+
+type ReusedEncodedVideoData struct {
+	uid       string
+	imageData []byte
+	frameInfo *agoraservice.EncodedVideoFrameInfo
+}
+
+type ReusedVideoFileWriter struct {
+	files map[string]*os.File
+	mutex sync.Mutex
+}
+
+func NewReusedVideoFileWriter() *ReusedVideoFileWriter {
+	return &ReusedVideoFileWriter{files: make(map[string]*os.File)}
+}
+
+func (w *ReusedVideoFileWriter) WriteVideoData(username string, imageData []byte) error {
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+	file, exists := w.files[username]
+	if !exists {
+		filename := fmt.Sprintf("./recv_%s.h264", username)
+		var err error
+		file, err = os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+		if err != nil {
+			return err
+		}
+		w.files[username] = file
+	}
+	_, err := file.Write(imageData)
+	return err
+}
+
+func (w *ReusedVideoFileWriter) CloseAll() {
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+	for _, file := range w.files {
+		file.Close()
+	}
+	w.files = make(map[string]*os.File)
+}
+
+func main() {
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		c := make(chan os.Signal, 1)
+		signal.Notify(c, os.Interrupt)
+		<-c
+		cancel()
+	}()
+
+	args := os.Args
+	if len(args) < 3 {
+		fmt.Println("Please input appid, channel name")
+		return
+	}
+	appid := args[1]
+	channelName := args[2]
+	if appid == "" {
+		appid = os.Getenv("AGORA_APP_ID")
+	}
+	cert := os.Getenv("AGORA_APP_CERTIFICATE")
+	userId := "0"
+	if appid == "" {
+		fmt.Println("Please set AGORA_APP_ID environment variable, and AGORA_APP_CERTIFICATE if needed")
+		return
+	}
+	token := ""
+	if cert != "" {
+		tokenExpirationInSeconds := uint32(3600)
+		privilegeExpirationInSeconds := uint32(3600)
+		var err error
+		token, err = rtctokenbuilder.BuildTokenWithUserAccount(appid, cert, channelName, userId,
+			rtctokenbuilder.RolePublisher, tokenExpirationInSeconds, privilegeExpirationInSeconds)
+		if err != nil {
+			fmt.Println("Failed to build token: ", err)
+			return
+		}
+	}
+
+	svcCfg := agoraservice.NewAgoraServiceConfig()
+	svcCfg.EnableVideo = true
+	svcCfg.AppId = appid
+	svcCfg.LogPath = "./agora_rtc_log/agrasdk.log"
+	agoraservice.Initialize(svcCfg)
+
+	writer := NewReusedVideoFileWriter()
+	defer writer.CloseAll()
+
+	conSignal := make(chan struct{})
+	conHandler := &agoraservice.RtcConnectionObserver{
+		OnConnected: func(con *agoraservice.RtcConnection, info *agoraservice.RtcConnectionInfo, reason int) {
+			fmt.Printf("Connected, reason %d\n", reason)
+			conSignal <- struct{}{}
+		},
+		OnConnectionFailure: func(con *agoraservice.RtcConnection, conInfo *agoraservice.RtcConnectionInfo, errCode int) {
+			fmt.Printf("Connection failure, error code %d\n", errCode)
+		},
+	}
+
+	videoChan := make(chan *ReusedEncodedVideoData, 100)
+	lastKeyFrameTime := time.Now().UnixMilli()
+	encodedVideoObserver := &agoraservice.VideoEncodedFrameObserver{
+		OnReusedEncodedVideoFrame: func(uid string, imageBuffer []byte, frameInfo *agoraservice.EncodedVideoFrameInfo) bool {
+			fmt.Printf("user %s encoded video received, frame type %d\n", uid, frameInfo.FrameType)
+			if frameInfo.FrameType == agoraservice.VideoFrameTypeKeyFrame {
+				fmt.Printf("key frame received, time %d, codec type %d\n", time.Now().UnixMilli()-lastKeyFrameTime, frameInfo.CodecType)
+				lastKeyFrameTime = time.Now().UnixMilli()
+			}
+			imageCopy := append([]byte(nil), imageBuffer...)
+			videoChan <- &ReusedEncodedVideoData{
+				uid:       uid,
+				imageData: imageCopy,
+				frameInfo: frameInfo,
+			}
+			return true
+		},
+	}
+
+	conCfg := &agoraservice.RtcConnectionConfig{
+		AutoSubscribeAudio: true,
+		AutoSubscribeVideo: true,
+		ClientRole:         agoraservice.ClientRoleBroadcaster,
+		ChannelProfile:     agoraservice.ChannelProfileLiveBroadcasting,
+	}
+	publishConfig := agoraservice.NewRtcConPublishConfig()
+	publishConfig.AudioScenario = agoraservice.AudioScenarioDefault
+	publishConfig.IsPublishAudio = true
+	publishConfig.IsPublishVideo = true
+	publishConfig.AudioProfile = agoraservice.AudioProfileDefault
+	publishConfig.AudioPublishType = agoraservice.AudioPublishTypeNoPublish
+	publishConfig.VideoPublishType = agoraservice.VideoPublishTypeEncodedImage
+	publishConfig.AudioPublishType = agoraservice.AudioPublishTypePcm
+
+	con := agoraservice.NewRtcConnection(conCfg, publishConfig)
+	subvideoopt := &agoraservice.VideoSubscriptionOptions{
+		StreamType:       agoraservice.VideoStreamHigh,
+		EncodedFrameOnly: true,
+	}
+	con.GetLocalUser().SubscribeAllVideo(subvideoopt)
+	con.RegisterObserver(conHandler)
+	con.RegisterVideoEncodedFrameObserver(encodedVideoObserver)
+	con.Connect(token, channelName, userId)
+	<-conSignal
+
+	stop := false
+	for !stop {
+		select {
+		case videoData := <-videoChan:
+			_ = writer.WriteVideoData(videoData.uid, videoData.imageData)
+		case <-ctx.Done():
+			stop = true
+		default:
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+
+	con.Disconnect()
+	con.Release()
+	agoraservice.Release()
+}

--- a/go_sdk/examples/recv_pcm_reused/recv_pcm_reused.go
+++ b/go_sdk/examples/recv_pcm_reused/recv_pcm_reused.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"time"
+
+	agoraservice "github.com/AgoraIO-Extensions/Agora-Golang-Server-SDK/v2/go_sdk/rtc"
+
+	rtctokenbuilder "github.com/AgoraIO/Tools/DynamicKey/AgoraDynamicKey/go/src/rtctokenbuilder2"
+)
+
+func main() {
+	stop := false
+	go func() {
+		c := make(chan os.Signal, 1)
+		signal.Notify(c, os.Interrupt)
+		<-c
+		stop = true
+	}()
+
+	args := os.Args
+	if len(args) < 3 {
+		fmt.Println("usage: recv_pcm_reused <appid> <channel_name> [output.pcm]")
+		return
+	}
+	appid := args[1]
+	channelName := args[2]
+	outputPath := "./recv_reused_playback.pcm"
+	if len(args) > 3 {
+		outputPath = args[3]
+	}
+
+	if appid == "" {
+		appid = os.Getenv("AGORA_APP_ID")
+	}
+	cert := os.Getenv("AGORA_APP_CERTIFICATE")
+	userId := "reused_pcm_recv"
+	if appid == "" {
+		fmt.Println("Please set AGORA_APP_ID or pass it as the first argument")
+		return
+	}
+
+	token := ""
+	if cert != "" {
+		tokenExpirationInSeconds := uint32(3600)
+		privilegeExpirationInSeconds := uint32(3600)
+		var err error
+		token, err = rtctokenbuilder.BuildTokenWithUserAccount(appid, cert, channelName, userId,
+			rtctokenbuilder.RolePublisher, tokenExpirationInSeconds, privilegeExpirationInSeconds)
+		if err != nil {
+			fmt.Println("Failed to build token:", err)
+			return
+		}
+	}
+
+	outFile, err := os.OpenFile(outputPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	if err != nil {
+		fmt.Println("Failed to open output file:", err)
+		return
+	}
+	defer outFile.Close()
+
+	svcCfg := agoraservice.NewAgoraServiceConfig()
+	svcCfg.AppId = appid
+	svcCfg.LogPath = "./agora_rtc_log/agorasdk.log"
+	svcCfg.ConfigDir = "./agora_rtc_log"
+	svcCfg.DataDir = "./agora_rtc_log"
+
+	agoraservice.Initialize(svcCfg)
+	defer agoraservice.Release()
+
+	conCfg := &agoraservice.RtcConnectionConfig{
+		AutoSubscribeAudio: true,
+		AutoSubscribeVideo: false,
+		ClientRole:         agoraservice.ClientRoleAudience,
+		ChannelProfile:     agoraservice.ChannelProfileLiveBroadcasting,
+	}
+	publishConfig := agoraservice.NewRtcConPublishConfig()
+	publishConfig.AudioPublishType = agoraservice.AudioPublishTypeNoPublish
+	publishConfig.AudioScenario = agoraservice.AudioScenarioDefault
+	publishConfig.IsPublishAudio = false
+	publishConfig.IsPublishVideo = false
+	publishConfig.AudioProfile = agoraservice.AudioProfileDefault
+
+	con := agoraservice.NewRtcConnection(conCfg, publishConfig)
+	if con == nil {
+		fmt.Println("Failed to create RTC connection")
+		return
+	}
+	defer con.Release()
+
+	conSignal := make(chan struct{})
+	audioFrameCount := 0
+	lastLogTime := time.Now()
+
+	conHandler := &agoraservice.RtcConnectionObserver{
+		OnConnected: func(con *agoraservice.RtcConnection, info *agoraservice.RtcConnectionInfo, reason int) {
+			fmt.Printf("Connected, reason %d\n", reason)
+			conSignal <- struct{}{}
+		},
+		OnDisconnected: func(con *agoraservice.RtcConnection, info *agoraservice.RtcConnectionInfo, reason int) {
+			fmt.Printf("Disconnected, reason %d\n", reason)
+		},
+		OnUserJoined: func(con *agoraservice.RtcConnection, uid string) {
+			fmt.Println("user joined,", uid)
+		},
+		OnUserLeft: func(con *agoraservice.RtcConnection, uid string, reason int) {
+			fmt.Println("user left,", uid)
+		},
+	}
+
+	audioObserver := &agoraservice.AudioFrameObserver{
+		OnReusedPlaybackAudioFrame: func(localUser *agoraservice.LocalUser, channelId string, frame *agoraservice.AudioFrame) bool {
+			if frame == nil || len(frame.Buffer) == 0 {
+				return true
+			}
+			pcmCopy := append([]byte(nil), frame.Buffer...)
+			if _, err := outFile.Write(pcmCopy); err != nil {
+				fmt.Println("write pcm failed:", err)
+				return false
+			}
+			audioFrameCount++
+			if time.Since(lastLogTime) >= time.Second {
+				fmt.Printf("reused playback audio ok, frames=%d bytes_per_frame=%d channel=%s sample_rate=%d\n",
+					audioFrameCount, len(pcmCopy), channelId, frame.SamplesPerSec)
+				audioFrameCount = 0
+				lastLogTime = time.Now()
+			}
+			return true
+		},
+		OnGetPlaybackAudioFrameParam: func(localUser *agoraservice.LocalUser) agoraservice.AudioFrameObserverAudioParams {
+			return agoraservice.AudioFrameObserverAudioParams{
+				SampleRate:     16000,
+				Channels:       1,
+				Mode:           agoraservice.RawAudioFrameOpModeReadOnly,
+				SamplesPerCall: 320,
+			}
+		},
+	}
+
+	localUserObserver := &agoraservice.LocalUserObserver{
+		OnUserAudioTrackSubscribed: func(localUser *agoraservice.LocalUser, uid string, remoteAudioTrack *agoraservice.RemoteAudioTrack) {
+			fmt.Printf("user %s audio subscribed\n", uid)
+		},
+	}
+
+	con.RegisterObserver(conHandler)
+	con.RegisterLocalUserObserver(localUserObserver)
+	con.RegisterAudioFrameObserver(audioObserver, 0, nil)
+
+	con.Connect(token, channelName, userId)
+	<-conSignal
+
+	for !stop {
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	con.Disconnect()
+}

--- a/go_sdk/examples/send_recv_yuv_reused/send_recv_yuv_reused.go
+++ b/go_sdk/examples/send_recv_yuv_reused/send_recv_yuv_reused.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"time"
+
+	agoraservice "github.com/AgoraIO-Extensions/Agora-Golang-Server-SDK/v2/go_sdk/rtc"
+	rtctokenbuilder "github.com/AgoraIO/Tools/DynamicKey/AgoraDynamicKey/go/src/rtctokenbuilder2"
+)
+
+func main() {
+	bStop := new(bool)
+	*bStop = false
+	go func() {
+		c := make(chan os.Signal, 1)
+		signal.Notify(c, os.Interrupt)
+		<-c
+		*bStop = true
+		fmt.Println("Application terminated")
+	}()
+
+	argus := os.Args
+	if len(argus) < 3 {
+		fmt.Println("Please input appid, channel name")
+		return
+	}
+	appid := argus[1]
+	channelName := argus[2]
+	cert := os.Getenv("AGORA_APP_CERTIFICATE")
+	userId := "0"
+	if appid == "" {
+		fmt.Println("Please set AGORA_APP_ID environment variable, and AGORA_APP_CERTIFICATE if needed")
+		return
+	}
+	token := ""
+	if cert != "" {
+		tokenExpirationInSeconds := uint32(3600)
+		privilegeExpirationInSeconds := uint32(3600)
+		var err error
+		token, err = rtctokenbuilder.BuildTokenWithUserAccount(appid, cert, channelName, userId,
+			rtctokenbuilder.RolePublisher, tokenExpirationInSeconds, privilegeExpirationInSeconds)
+		if err != nil {
+			fmt.Println("Failed to build token: ", err)
+			return
+		}
+	}
+
+	svcCfg := agoraservice.NewAgoraServiceConfig()
+	svcCfg.EnableVideo = true
+	svcCfg.AppId = appid
+	svcCfg.LogPath = "./agora_rtc_log/agorasdk.log"
+	svcCfg.ConfigDir = "./agora_rtc_log"
+	svcCfg.DataDir = "./agora_rtc_log"
+	agoraservice.Initialize(svcCfg)
+
+	conCfg := agoraservice.RtcConnectionConfig{
+		AutoSubscribeAudio: true,
+		AutoSubscribeVideo: true,
+		ClientRole:         agoraservice.ClientRoleBroadcaster,
+		ChannelProfile:     agoraservice.ChannelProfileLiveBroadcasting,
+	}
+	publishConfig := agoraservice.NewRtcConPublishConfig()
+	publishConfig.AudioPublishType = agoraservice.AudioPublishTypePcm
+	publishConfig.AudioScenario = agoraservice.AudioScenarioDefault
+	publishConfig.IsPublishAudio = true
+	publishConfig.IsPublishVideo = true
+	publishConfig.VideoPublishType = agoraservice.VideoPublishTypeYuv
+	publishConfig.AudioProfile = agoraservice.AudioProfileDefault
+
+	conSignal := make(chan struct{})
+	conHandler := &agoraservice.RtcConnectionObserver{
+		OnConnected: func(con *agoraservice.RtcConnection, info *agoraservice.RtcConnectionInfo, reason int) {
+			fmt.Printf("Connected, reason %d\n", reason)
+			conSignal <- struct{}{}
+		},
+		OnDisconnected: func(con *agoraservice.RtcConnection, info *agoraservice.RtcConnectionInfo, reason int) {
+			fmt.Printf("Disconnected, reason %d\n", reason)
+		},
+		OnUserJoined: func(con *agoraservice.RtcConnection, uid string) {
+			fmt.Println("user joined, " + uid)
+		},
+		OnUserLeft: func(con *agoraservice.RtcConnection, uid string, reason int) {
+			fmt.Println("user left, " + uid)
+		},
+	}
+
+	frameCount := 0
+	frameLastRecvTime := time.Now().UnixMilli()
+	copiedFrameCount := 0
+	videoObserver := &agoraservice.VideoFrameObserver{
+		OnReusedFrame: func(channelId string, userId string, frame *agoraservice.VideoFrame) bool {
+			if frame == nil {
+				return true
+			}
+			yCopy := append([]byte(nil), frame.YBuffer...)
+			uCopy := append([]byte(nil), frame.UBuffer...)
+			vCopy := append([]byte(nil), frame.VBuffer...)
+			if len(yCopy) == 0 || len(uCopy) == 0 || len(vCopy) == 0 {
+				fmt.Printf("invalid reused frame copy, channel=%s user=%s y=%d u=%d v=%d\n",
+					channelId, userId, len(yCopy), len(uCopy), len(vCopy))
+				return false
+			}
+			copiedFrameCount++
+			frameCount++
+			now := time.Now().UnixMilli()
+			if now-frameLastRecvTime > 1000 {
+				fps := int64(frameCount*1000) / (now - frameLastRecvTime)
+				fmt.Printf("reused raw video ok, copied=%d fps=%d y=%d u=%d v=%d\n",
+					copiedFrameCount, fps, len(yCopy), len(uCopy), len(vCopy))
+				frameCount = 0
+				copiedFrameCount = 0
+				frameLastRecvTime = now
+			}
+			return true
+		},
+	}
+
+	con := agoraservice.NewRtcConnection(&conCfg, publishConfig)
+	con.RegisterObserver(conHandler)
+	con.RegisterVideoFrameObserver(videoObserver)
+	con.Connect(token, channelName, userId)
+	<-conSignal
+
+	encoderCfg := agoraservice.NewVideoEncoderConfiguration()
+	encoderCfg.Width = 960
+	encoderCfg.Height = 720
+	encoderCfg.Framerate = 20
+	encoderCfg.Bitrate = 1700
+	encoderCfg.MinBitrate = -1
+	encoderCfg.CodecType = agoraservice.VideoCodecTypeAv1
+	con.SetVideoEncoderConfiguration(encoderCfg)
+	con.PublishVideo()
+
+	w := 960
+	h := 720
+	file, err := os.Open("../test_data/960-720.yuv")
+	if err != nil {
+		fmt.Println("Error opening file:", err)
+		return
+	}
+	defer file.Close()
+
+	con.GetLocalUser().SubscribeAllVideo(&agoraservice.VideoSubscriptionOptions{
+		StreamType:       agoraservice.VideoStreamLow,
+		EncodedFrameOnly: false,
+	})
+
+	dataSize := w * h * 3 / 2
+	data := make([]byte, dataSize)
+	for !*bStop {
+		dataLen, err := file.Read(data)
+		if err != nil || dataLen < dataSize {
+			file.Seek(0, 0)
+			continue
+		}
+		frame := &agoraservice.ExternalVideoFrame{
+			Type:      agoraservice.VideoBufferRawData,
+			Format:    agoraservice.VideoPixelI420,
+			Buffer:    data,
+			Stride:    w,
+			Height:    h,
+			Timestamp: 0,
+		}
+		con.PushVideoFrame(frame)
+		time.Sleep(33 * time.Millisecond)
+	}
+}

--- a/go_sdk/rtc/audio_observer.go
+++ b/go_sdk/rtc/audio_observer.go
@@ -22,16 +22,17 @@ func goOnRecordAudioFrame(cLocalUser unsafe.Pointer, channelId *C.char, frame *C
 	}
 	// get conn from handle
 	con := agoraService.getConFromHandle(cLocalUser, ConTypeCLocalUser)
-	if con == nil || con.audioObserver == nil || con.audioObserver.OnRecordAudioFrame == nil {
+	if con == nil || con.audioObserver == nil {
 		return C.int(0)
 	}
 	goChannelId := C.GoString(channelId)
-	goFrame := GoPcmAudioFrame(frame)
-	ret := con.audioObserver.OnRecordAudioFrame(con.GetLocalUser(), goChannelId, goFrame)
-	if ret {
-		return C.int(1)
-	}
-	return C.int(0)
+	return dispatchAudioFrameWithChannel(
+		con.GetLocalUser(),
+		goChannelId,
+		frame,
+		con.audioObserver.OnReusedRecordAudioFrame,
+		con.audioObserver.OnRecordAudioFrame,
+	)
 }
 
 //export goOnPlaybackAudioFrame
@@ -43,16 +44,17 @@ func goOnPlaybackAudioFrame(cLocalUser unsafe.Pointer, channelId *C.char, frame 
 	// get conn from handle
 	con := agoraService.getConFromHandle(cLocalUser, ConTypeCLocalUser)
 
-	if con == nil || con.audioObserver == nil || con.audioObserver.OnPlaybackAudioFrame == nil {
+	if con == nil || con.audioObserver == nil {
 		return C.int(0)
 	}
 	goChannelId := C.GoString(channelId)
-	goFrame := GoPcmAudioFrame(frame)
-	ret := con.audioObserver.OnPlaybackAudioFrame(con.GetLocalUser(), goChannelId, goFrame)
-	if ret {
-		return C.int(1)
-	}
-	return C.int(0)
+	return dispatchAudioFrameWithChannel(
+		con.GetLocalUser(),
+		goChannelId,
+		frame,
+		con.audioObserver.OnReusedPlaybackAudioFrame,
+		con.audioObserver.OnPlaybackAudioFrame,
+	)
 }
 
 //export goOnMixedAudioFrame
@@ -64,16 +66,17 @@ func goOnMixedAudioFrame(cLocalUser unsafe.Pointer, channelId *C.char, frame *C.
 	// get conn from handle
 	con := agoraService.getConFromHandle(cLocalUser, ConTypeCLocalUser)
 
-	if con == nil || con.audioObserver == nil || con.audioObserver.OnMixedAudioFrame == nil {
+	if con == nil || con.audioObserver == nil {
 		return C.int(0)
 	}
 	goChannelId := C.GoString(channelId)
-	goFrame := GoPcmAudioFrame(frame)
-	ret := con.audioObserver.OnMixedAudioFrame(con.GetLocalUser(), goChannelId, goFrame)
-	if ret {
-		return C.int(1)
-	}
-	return C.int(0)
+	return dispatchAudioFrameWithChannel(
+		con.GetLocalUser(),
+		goChannelId,
+		frame,
+		con.audioObserver.OnReusedMixedAudioFrame,
+		con.audioObserver.OnMixedAudioFrame,
+	)
 }
 
 //export goOnEarMonitoringAudioFrame
@@ -85,15 +88,15 @@ func goOnEarMonitoringAudioFrame(cLocalUser unsafe.Pointer, frame *C.struct__aud
 	// get conn from handle
 	con := agoraService.getConFromHandle(cLocalUser, ConTypeCLocalUser)
 
-	if con == nil || con.audioObserver == nil || con.audioObserver.OnEarMonitoringAudioFrame == nil {
+	if con == nil || con.audioObserver == nil {
 		return C.int(0)
 	}
-	goFrame := GoPcmAudioFrame(frame)
-	ret := con.audioObserver.OnEarMonitoringAudioFrame(con.GetLocalUser(), goFrame)
-	if ret {
-		return C.int(1)
-	}
-	return C.int(0)
+	return dispatchAudioFrame(
+		con.GetLocalUser(),
+		frame,
+		con.audioObserver.OnReusedEarMonitoringAudioFrame,
+		con.audioObserver.OnEarMonitoringAudioFrame,
+	)
 }
 
 //export goOnPlaybackAudioFrameBeforeMixing
@@ -114,14 +117,13 @@ func goOnPlaybackAudioFrameBeforeMixing(cLocalUser unsafe.Pointer, channelId *C.
 	var ret bool = false
 	var vadResultFrame *AudioFrame = nil
 	var vadResultStat VadState = VadStateInvalid
-	
+
 	if con.audioVadManager != nil {
 		vadResultFrame, vadResultStat = con.audioVadManager.Process(goChannelId, goUid, goFrame)
 	}
 	ret = con.audioObserver.OnPlaybackAudioFrameBeforeMixing(con.GetLocalUser(), goChannelId, goUid, goFrame, vadResultStat, vadResultFrame)
 
-	
-	if ret  {
+	if ret {
 		return C.int(1)
 	}
 	return C.int(0)
@@ -231,4 +233,47 @@ func goOnGetEarMonitoringAudioFrameParam(cLocalUser unsafe.Pointer) C.struct__au
 	cAudioParam.mode = C.RAW_AUDIO_FRAME_OP_MODE_TYPE(goAudioParam.Mode)
 	cAudioParam.samples_per_call = C.int(goAudioParam.SamplesPerCall)
 	return cAudioParam
+}
+
+func dispatchAudioFrameWithChannel(
+	localUser *LocalUser,
+	channelId string,
+	frame *C.struct__audio_frame,
+	reused func(localUser *LocalUser, channelId string, frame *AudioFrame) bool,
+	copied func(localUser *LocalUser, channelId string, frame *AudioFrame) bool,
+) C.int {
+	if reused == nil && copied == nil {
+		return C.int(0)
+	}
+	if reused != nil {
+		if reused(localUser, channelId, GoPcmAudioFrameReused(frame)) {
+			return C.int(1)
+		}
+		return C.int(0)
+	}
+	if copied(localUser, channelId, GoPcmAudioFrame(frame)) {
+		return C.int(1)
+	}
+	return C.int(0)
+}
+
+func dispatchAudioFrame(
+	localUser *LocalUser,
+	frame *C.struct__audio_frame,
+	reused func(localUser *LocalUser, frame *AudioFrame) bool,
+	copied func(localUser *LocalUser, frame *AudioFrame) bool,
+) C.int {
+	if reused == nil && copied == nil {
+		return C.int(0)
+	}
+	if reused != nil {
+		if reused(localUser, GoPcmAudioFrameReused(frame)) {
+			return C.int(1)
+		}
+		return C.int(0)
+	}
+	if copied(localUser, GoPcmAudioFrame(frame)) {
+		return C.int(1)
+	}
+	return C.int(0)
 }

--- a/go_sdk/rtc/rtc_connection.go
+++ b/go_sdk/rtc/rtc_connection.go
@@ -288,16 +288,38 @@ type LocalUserObserver struct {
 	// added on 2026-03-05
 	OnVideoTrackPublishSuccess func(localUser *LocalUser, localVideoTrack *LocalVideoTrack)
 	OnVideoTrackUnpublished    func(localUser *LocalUser, localVideoTrack *LocalVideoTrack)
-
-	
 }
 
 type AudioFrameObserver struct {
-	OnRecordAudioFrame                func(localUser *LocalUser, channelId string, frame *AudioFrame) bool
-	OnPlaybackAudioFrame              func(localUser *LocalUser, channelId string, frame *AudioFrame) bool
-	OnMixedAudioFrame                 func(localUser *LocalUser, channelId string, frame *AudioFrame) bool
-	OnEarMonitoringAudioFrame         func(localUser *LocalUser, frame *AudioFrame) bool
-	OnPlaybackAudioFrameBeforeMixing  func(localUser *LocalUser, channelId string, uid string, frame *AudioFrame, vadResultStat VadState, vadResultFrame *AudioFrame) bool
+	OnRecordAudioFrame               func(localUser *LocalUser, channelId string, frame *AudioFrame) bool
+	OnPlaybackAudioFrame             func(localUser *LocalUser, channelId string, frame *AudioFrame) bool
+	OnMixedAudioFrame                func(localUser *LocalUser, channelId string, frame *AudioFrame) bool
+	OnEarMonitoringAudioFrame        func(localUser *LocalUser, frame *AudioFrame) bool
+	OnPlaybackAudioFrameBeforeMixing func(localUser *LocalUser, channelId string, uid string, frame *AudioFrame, vadResultStat VadState, vadResultFrame *AudioFrame) bool
+	// OnReusedRecordAudioFrame exposes a zero-copy view of the SDK-owned audio
+	// buffer. The frame and its buffer are only valid during the callback. If
+	// the data is needed after the callback returns or from another goroutine,
+	// copy it inside the callback before returning. The buffer must be treated
+	// as read-only.
+	OnReusedRecordAudioFrame func(localUser *LocalUser, channelId string, frame *AudioFrame) bool
+	// OnReusedPlaybackAudioFrame exposes a zero-copy view of the SDK-owned audio
+	// buffer. The frame and its buffer are only valid during the callback. If
+	// the data is needed after the callback returns or from another goroutine,
+	// copy it inside the callback before returning. The buffer must be treated
+	// as read-only.
+	OnReusedPlaybackAudioFrame func(localUser *LocalUser, channelId string, frame *AudioFrame) bool
+	// OnReusedMixedAudioFrame exposes a zero-copy view of the SDK-owned audio
+	// buffer. The frame and its buffer are only valid during the callback. If
+	// the data is needed after the callback returns or from another goroutine,
+	// copy it inside the callback before returning. The buffer must be treated
+	// as read-only.
+	OnReusedMixedAudioFrame func(localUser *LocalUser, channelId string, frame *AudioFrame) bool
+	// OnReusedEarMonitoringAudioFrame exposes a zero-copy view of the
+	// SDK-owned audio buffer. The frame and its buffer are only valid during
+	// the callback. If the data is needed after the callback returns or from
+	// another goroutine, copy it inside the callback before returning. The
+	// buffer must be treated as read-only.
+	OnReusedEarMonitoringAudioFrame   func(localUser *LocalUser, frame *AudioFrame) bool
 	OnGetAudioFramePosition           func(localUser *LocalUser) int
 	OnGetPlaybackAudioFrameParam      func(localUser *LocalUser) AudioFrameObserverAudioParams
 	OnGetRecordAudioFrameParam        func(localUser *LocalUser) AudioFrameObserverAudioParams
@@ -307,10 +329,23 @@ type AudioFrameObserver struct {
 
 type VideoFrameObserver struct {
 	OnFrame func(channelId string, userId string, frame *VideoFrame) bool
+	// OnReusedFrame exposes a zero-copy view of the SDK-owned frame buffers.
+	// The frame and its byte slices are only valid during the callback. If the
+	// data is needed after the callback returns or from another goroutine, copy
+	// it inside the callback before returning. The buffers must be treated as
+	// read-only.
+	OnReusedFrame func(channelId string, userId string, frame *VideoFrame) bool
 }
 
 type VideoEncodedFrameObserver struct {
 	OnEncodedVideoFrame func(uid string, imageBuffer []byte,
+		frameInfo *EncodedVideoFrameInfo) bool
+	// OnReusedEncodedVideoFrame exposes a zero-copy view of the SDK-owned
+	// encoded frame buffer. The buffer is only valid during the callback. If
+	// the data is needed after the callback returns or from another goroutine,
+	// copy it inside the callback before returning. The buffer must be treated
+	// as read-only.
+	OnReusedEncodedVideoFrame func(uid string, imageBuffer []byte,
 		frameInfo *EncodedVideoFrameInfo) bool
 }
 
@@ -457,10 +492,10 @@ type RtcConnection struct {
 	// for transcoding
 	transcodingWorker *TranscodingWorker
 	// for video encoder configuration
-	videoEncoderConfiguration  *VideoEncoderConfiguration
+	videoEncoderConfiguration *VideoEncoderConfiguration
 
 	// for encoded audio frame observer
-	encodedAudioFrameObserver  *AudioEncodedFrameObserver
+	encodedAudioFrameObserver *AudioEncodedFrameObserver
 }
 
 // for pcm consumption stats
@@ -785,8 +820,6 @@ func (conn *RtcConnection) Connect(token string, channel string, uid string) int
 	}
 	// auto create data stream: from 0331 for datastream encryption support
 	conn.dataStreamId, _ = conn.createDataStream(false, false)
-	
-
 
 	conn.connInfo.ChannelId = channel
 	conn.connInfo.LocalUserId = uid
@@ -1087,9 +1120,9 @@ func (conn *RtcConnection) enableSteroEncodeMode() int {
 }
 
 type EncryptionConfig struct {
-	EncryptionMode    int
-	EncryptionKey     string
-	EncryptionKdfSalt []byte
+	EncryptionMode              int
+	EncryptionKey               string
+	EncryptionKdfSalt           []byte
 	DatastreamEncryptionEnabled bool
 }
 
@@ -1349,7 +1382,6 @@ func (conn *RtcConnection) PushVideoEncodedData(data []byte, frameInfo *EncodedV
 	}
 	return conn.encodedVideoSender.SendEncodedVideoImage(data, frameInfo)
 }
-
 
 // to pudate connction's scenario
 func (conn *RtcConnection) UpdateAudioSenario(scenario AudioScenario) int {
@@ -1716,9 +1748,8 @@ func (conn *RtcConnection) stopTranscodingWorker() int {
 	return 0
 }
 
-
 func (conn *RtcConnection) RegisterAudioEncodedFrameObserver(observer *AudioEncodedFrameObserver) int {
-	if conn == nil || conn.cConnection == nil  {
+	if conn == nil || conn.cConnection == nil {
 		return -2000
 	}
 	if observer == nil {
@@ -1726,7 +1757,7 @@ func (conn *RtcConnection) RegisterAudioEncodedFrameObserver(observer *AudioEnco
 	}
 	// 'hold' the observer
 	conn.encodedAudioFrameObserver = observer
-	
+
 	return 0
 }
 
@@ -1747,7 +1778,6 @@ func (conn *RtcConnection) unregisterAudioEncodedFrameObserver() int {
 		return -2001
 	}
 
-	
 	//iterate agoraService.encAudioFrameObserverItemsMap, when item.Con == conn, delete the item, and free the handle
 	agoraService.encAudioFrameObserverItemsMap.Range(func(key, value interface{}) bool {
 		if item, ok := value.(*EncAudioFrameObserverItem); ok {
@@ -1767,7 +1797,7 @@ func (conn *RtcConnection) unregisterAudioEncodedFrameObserver() int {
 		}
 		return false
 	})
-	return 0 
+	return 0
 }
 
 func (conn *RtcConnection) doUnregisterAudioEncodedFrameObserver(uid string) int {
@@ -1779,7 +1809,7 @@ func (conn *RtcConnection) doUnregisterAudioEncodedFrameObserver(uid string) int
 				conn.unregAudioEncFrameObserverItem(item)
 				// free the item
 				freeAudioEncodedFrameObserverItem(item)
-				
+
 				item.CObserver = nil
 				item.CObserverHandle = nil
 				item.CTrack = nil
@@ -1808,15 +1838,14 @@ func (conn *RtcConnection) initEncodedAudioFrameReceived(uid *C.char, cRemoteAud
 	uidStr := C.GoString(uid)
 
 	// iterate agoraService.encAudioFrameObserverItemsMap, find all items where item.Uid == uidStr, delete the item, and free the handle
-	
+
 	conn.doUnregisterAudioEncodedFrameObserver(uidStr)
-	
+
 	// create a new item
 	item := createAudioEncodedFrameObserverItem(uidStr, cRemoteAudioTrack, conn)
 	if item == nil {
 		return -3001
 	}
-
 
 	agoraService.setAudioEncObserToMap(item)
 
@@ -1826,7 +1855,7 @@ func (conn *RtcConnection) initEncodedAudioFrameReceived(uid *C.char, cRemoteAud
 	ret := C.agora_remote_audio_track_register_encoded_frame_rev_observer(persistTrack, cObserverHandle)
 
 	// store to sync map
-	fmt.Printf("initEncodedAudioFrameReceived, uid: %s, ret: %d, persistTrack: %p, cObserverHandle: %p\n", uidStr, ret, persistTrack, cObserverHandle	)
+	fmt.Printf("initEncodedAudioFrameReceived, uid: %s, ret: %d, persistTrack: %p, cObserverHandle: %p\n", uidStr, ret, persistTrack, cObserverHandle)
 
 	return 0
 }
@@ -1841,10 +1870,10 @@ func (conn *RtcConnection) doAudioTrackStateChanged(uid *C.char, cRemoteAudioTra
 		}
 	}
 
-	
 	return 0
 }
-//date: 20260408 add get sid api
+
+// date: 20260408 add get sid api
 // note: only after connection is connected, the sid is valid(not empty string),otherwise return empty string
 func (conn *RtcConnection) GetSid() string {
 	if conn == nil || conn.cConnection == nil {

--- a/go_sdk/rtc/type_convert.go
+++ b/go_sdk/rtc/type_convert.go
@@ -38,10 +38,10 @@ func CAgoraServiceConfig(cfg *AgoraServiceConfig) *C.struct__agora_service_confi
 	if cfg.LogPath != "" {
 		ret.log_file_path = C.CString(cfg.LogPath)
 	}
-	
+
 	ret.log_file_size_kb = C.uint32_t(cfg.LogSize)
 	ret.log_level = C.int(cfg.LogLevel)
-	
+
 	if cfg.ConfigDir != "" {
 		ret.config_dir = C.CString(cfg.ConfigDir)
 	}
@@ -49,14 +49,13 @@ func CAgoraServiceConfig(cfg *AgoraServiceConfig) *C.struct__agora_service_confi
 		ret.data_dir = C.CString(cfg.DataDir)
 	}
 
-
 	return ret
 }
 
 func FreeCAgoraServiceConfig(cfg *C.struct__agora_service_config) {
 	C.free(unsafe.Pointer(cfg.app_id))
 	if cfg.log_file_path != nil {
-	C.free(unsafe.Pointer(cfg.log_file_path))
+		C.free(unsafe.Pointer(cfg.log_file_path))
 	}
 	if cfg.config_dir != nil {
 		C.free(unsafe.Pointer(cfg.config_dir))
@@ -204,6 +203,27 @@ func GoPcmAudioFrame(frame *C.struct__audio_frame) *AudioFrame {
 	return ret
 }
 
+func GoPcmAudioFrameReused(frame *C.struct__audio_frame) *AudioFrame {
+	bufferLen := frame.samples_per_channel * frame.bytes_per_sample * frame.channels
+	ret := &AudioFrame{
+		Type:              AudioFrameType(frame._type),
+		SamplesPerChannel: int(frame.samples_per_channel),
+		BytesPerSample:    int(frame.bytes_per_sample),
+		Channels:          int(frame.channels),
+		SamplesPerSec:     int(frame.samples_per_sec),
+		Buffer:            cByteSlice(frame.buffer, bufferLen),
+		RenderTimeMs:      int64(frame.render_time_ms),
+		AvsyncType:        int(frame.avsync_type),
+		FarFieldFlag:      int(frame.far_filed_flag),
+		Rms:               int(frame.rms),
+		VoiceProb:         int(frame.voice_prob),
+		MusicProb:         int(frame.music_prob),
+		Pitch:             int(frame.pitch),
+		PresentTimeMs:     int64(frame.presentation_ms), // NOTE: next version, should include pts in audio_frame in c api layer!!??
+	}
+	return ret
+}
+
 func GoSinkAudioFrame(frame *C.struct__audio_pcm_frame) *AudioFrame {
 	bufferLen := int(frame.samples_per_channel) * int(frame.bytes_per_sample) * int(frame.num_channels)
 	samplepersec := int(frame.sample_rate_hz) * int(frame.num_channels)
@@ -256,6 +276,27 @@ func Uint8PtrToUintptr(p *C.uint8_t) uintptr {
 	return uintptr(unsafe.Pointer(p))
 }
 
+func cUint8Slice(ptr *C.uint8_t, length C.int) []byte {
+	if ptr == nil || length <= 0 {
+		return nil
+	}
+	return unsafe.Slice((*byte)(unsafe.Pointer(ptr)), int(length))
+}
+
+func cByteSlice(ptr unsafe.Pointer, length C.int) []byte {
+	if ptr == nil || length <= 0 {
+		return nil
+	}
+	return unsafe.Slice((*byte)(ptr), int(length))
+}
+
+func cUint8SliceFromSize(ptr *C.uint8_t, length C.size_t) []byte {
+	if ptr == nil || length == 0 {
+		return nil
+	}
+	return unsafe.Slice((*byte)(unsafe.Pointer(ptr)), int(length))
+}
+
 func GoVideoFrame(frame *C.struct__video_frame) *VideoFrame {
 	// var buf []byte = nil
 	// bufLen := frame.y_stride*frame.height + frame.u_stride*frame.height/2 + frame.v_stride*frame.height/2
@@ -301,6 +342,35 @@ func GoVideoFrame(frame *C.struct__video_frame) *VideoFrame {
 	return ret
 }
 
+func GoVideoFrameReused(frame *C.struct__video_frame) *VideoFrame {
+	yLen := frame.y_stride * frame.height
+	uLen := frame.u_stride * frame.height / 2
+	vLen := frame.v_stride * frame.height / 2
+	ret := &VideoFrame{
+		Type:           VideoBufferType(frame._type),
+		Width:          int(frame.width),
+		Height:         int(frame.height),
+		YStride:        int(frame.y_stride),
+		UStride:        int(frame.u_stride),
+		VStride:        int(frame.v_stride),
+		YBuffer:        cUint8Slice(frame.y_buffer, yLen),
+		UBuffer:        cUint8Slice(frame.u_buffer, uLen),
+		VBuffer:        cUint8Slice(frame.v_buffer, vLen),
+		Rotation:       VideoOrientation(frame.rotation),
+		RenderTimeMs:   int64(frame.render_time_ms),
+		AVSyncType:     int(frame.avsync_type),
+		MetadataBuffer: cUint8Slice(frame.metadata_buffer, frame.metadata_size),
+		SharedContext:  frame.shared_context,
+		TextureID:      int(frame.texture_id),
+		Matrix:         [16]float32{},
+		AlphaBuffer:    cUint8Slice(frame.alpha_buffer, yLen),
+	}
+	for i := 0; i < 16; i++ {
+		ret.Matrix[i] = float32(frame.matrix[i])
+	}
+	return ret
+}
+
 func GoVideoTrackInfo(cInfo *C.struct__video_track_info) *VideoTrackInfo {
 	ret := &VideoTrackInfo{
 		IsLocal:             (int(cInfo.is_local) != 0),
@@ -339,84 +409,82 @@ func GoAudioVolumeInfo(frame *C.struct__audio_volume_info) *AudioVolumeInfo {
 	return ret
 }
 
-
-
 func GoLocalAudioStats(stats *C.struct__local_audio_stats) *LocalAudioTrackStats {
 	ret := &LocalAudioTrackStats{
-		NumChannels: int(stats.num_channels),
+		NumChannels:    int(stats.num_channels),
 		SentSampleRate: int(stats.sent_sample_rate),
-		SentBitrate: int(stats.sent_bitrate),
-		InternalCodec: int(stats.internal_codec),
-		VoicePitch: float64(stats.voice_pitch),
+		SentBitrate:    int(stats.sent_bitrate),
+		InternalCodec:  int(stats.internal_codec),
+		VoicePitch:     float64(stats.voice_pitch),
 	}
 	return ret
 }
 func GoRemoteAudioStats(stats *C.struct__remote_audio_stats) *RemoteAudioTrackStats {
 	ret := &RemoteAudioTrackStats{
-		Uid: uint(stats.uid),
-		Quality: int(stats.quality),
+		Uid:                   uint(stats.uid),
+		Quality:               int(stats.quality),
 		NetworkTransportDelay: int(stats.network_transport_delay),
-		JitterBufferDelay: int(stats.jitter_buffer_delay),
-		AudioLossRate: int(stats.audio_loss_rate),
-		NumChannels: int(stats.num_channels),
-		ReceivedSampleRate: int(stats.received_sample_rate),
-		ReceivedBitrate: int(stats.received_bitrate),
-		TotalFrozenTime: int(stats.total_frozen_time), // ms
-		FrozenRate: int(stats.frozen_rate),
-		MosValue: int(stats.mos_value),
-		TotalActiveTime: int(stats.total_active_time), // ms
-		PublishDuration: int(stats.publish_duration), // ms
+		JitterBufferDelay:     int(stats.jitter_buffer_delay),
+		AudioLossRate:         int(stats.audio_loss_rate),
+		NumChannels:           int(stats.num_channels),
+		ReceivedSampleRate:    int(stats.received_sample_rate),
+		ReceivedBitrate:       int(stats.received_bitrate),
+		TotalFrozenTime:       int(stats.total_frozen_time), // ms
+		FrozenRate:            int(stats.frozen_rate),
+		MosValue:              int(stats.mos_value),
+		TotalActiveTime:       int(stats.total_active_time), // ms
+		PublishDuration:       int(stats.publish_duration),  // ms
 	}
-	return ret	
+	return ret
 }
 func GoLocalVideoStats(stats *C.struct__local_video_track_stats) *LocalVideoTrackStats {
 	ret := &LocalVideoTrackStats{
-		NumberOfStreams: uint64(stats.number_of_streams),
-		BytesMajorStream: uint64(stats.bytes_major_stream),
-		BytesMinorStream: uint64(stats.bytes_minor_stream),
-		FramesEncoded: uint32(stats.frames_encoded),
-		SSRCMajorStream: uint32(stats.ssrc_major_stream),
-		SSRCMinorStream: uint32(stats.ssrc_minor_stream),
-		CaptureFrameRate: int(stats.capture_frame_rate),
+		NumberOfStreams:           uint64(stats.number_of_streams),
+		BytesMajorStream:          uint64(stats.bytes_major_stream),
+		BytesMinorStream:          uint64(stats.bytes_minor_stream),
+		FramesEncoded:             uint32(stats.frames_encoded),
+		SSRCMajorStream:           uint32(stats.ssrc_major_stream),
+		SSRCMinorStream:           uint32(stats.ssrc_minor_stream),
+		CaptureFrameRate:          int(stats.capture_frame_rate),
 		RegulatedCaptureFrameRate: int(stats.regulated_capture_frame_rate),
-		InputFrameRate: int(stats.input_frame_rate),
-		EncodeFrameRate: int(stats.encode_frame_rate),
-		RenderFrameRate: int(stats.render_frame_rate),
-		TargetMediaBitrateBps: int(stats.target_media_bitrate_bps),
-		MediaBitrateBps: int(stats.media_bitrate_bps),
-		TotalBitrateBps: int(stats.total_bitrate_bps),
-		CaptureWidth: int(stats.capture_width),
-		CaptureHeight: int(stats.capture_height),
-		RegulatedCaptureWidth: int(stats.regulated_capture_width),
-		RegulatedCaptureHeight: int(stats.regulated_capture_height),
-		Width: int(stats.width),
-		Height: int(stats.height),
-		EncoderType: uint32(stats.encoder_type),
-		UplinkCostTimeMs: int(stats.uplink_cost_time_ms),
-		QualityAdaptIndication: int(stats.quality_adapt_indication),
+		InputFrameRate:            int(stats.input_frame_rate),
+		EncodeFrameRate:           int(stats.encode_frame_rate),
+		RenderFrameRate:           int(stats.render_frame_rate),
+		TargetMediaBitrateBps:     int(stats.target_media_bitrate_bps),
+		MediaBitrateBps:           int(stats.media_bitrate_bps),
+		TotalBitrateBps:           int(stats.total_bitrate_bps),
+		CaptureWidth:              int(stats.capture_width),
+		CaptureHeight:             int(stats.capture_height),
+		RegulatedCaptureWidth:     int(stats.regulated_capture_width),
+		RegulatedCaptureHeight:    int(stats.regulated_capture_height),
+		Width:                     int(stats.width),
+		Height:                    int(stats.height),
+		EncoderType:               uint32(stats.encoder_type),
+		UplinkCostTimeMs:          int(stats.uplink_cost_time_ms),
+		QualityAdaptIndication:    int(stats.quality_adapt_indication),
 	}
 	return ret
 }
 func GoRemoteVideoStats(stats *C.struct__remote_video_track_stats) *RemoteVideoTrackStats {
 	ret := &RemoteVideoTrackStats{
-		Uid: uint(stats.uid),
-		Delay: int(stats.delay),
-		Width: int(stats.width),
-		Height: int(stats.height),
-		ReceivedBitrate: int(stats.received_bitrate),
-		DecoderOutputFrameRate: int(stats.decoder_output_frame_rate),
+		Uid:                     uint(stats.uid),
+		Delay:                   int(stats.delay),
+		Width:                   int(stats.width),
+		Height:                  int(stats.height),
+		ReceivedBitrate:         int(stats.received_bitrate),
+		DecoderOutputFrameRate:  int(stats.decoder_output_frame_rate),
 		RendererOutputFrameRate: int(stats.renderer_output_frame_rate),
-		FrameLossRate: int(stats.frame_loss_rate),
-		PacketLossRate: int(stats.packet_loss_rate),
-		RxStreamType: int(stats.rx_stream_type),
-		TotalFrozenTime: int(stats.total_frozen_time), // ms
-		FrozenRate: int(stats.frozen_rate),
-		TotalDecodedFrames: uint32(stats.total_decoded_frames),
-		AvSyncTimeMs: int(stats.av_sync_time_ms),
-		DownlinkProcessTimeMs: int(stats.downlink_process_time_ms),
-		FrameRenderDelayMs: int(stats.frame_render_delay_ms),
-		TotalActiveTime: uint64(stats.totalActiveTime), // ms
-		PublishDuration: uint64(stats.publishDuration), // ms
+		FrameLossRate:           int(stats.frame_loss_rate),
+		PacketLossRate:          int(stats.packet_loss_rate),
+		RxStreamType:            int(stats.rx_stream_type),
+		TotalFrozenTime:         int(stats.total_frozen_time), // ms
+		FrozenRate:              int(stats.frozen_rate),
+		TotalDecodedFrames:      uint32(stats.total_decoded_frames),
+		AvSyncTimeMs:            int(stats.av_sync_time_ms),
+		DownlinkProcessTimeMs:   int(stats.downlink_process_time_ms),
+		FrameRenderDelayMs:      int(stats.frame_render_delay_ms),
+		TotalActiveTime:         uint64(stats.totalActiveTime), // ms
+		PublishDuration:         uint64(stats.publishDuration), // ms
 	}
 	return ret
 }
@@ -441,12 +509,13 @@ type AudioEncodedFrameObserver struct {
 }
 
 type EncAudioFrameObserverItem struct {
-	Uid string
-	Con *RtcConnection
-	CObserver *C.struct__audio_encoded_frame_rev_observer
-	CTrack unsafe.Pointer
+	Uid             string
+	Con             *RtcConnection
+	CObserver       *C.struct__audio_encoded_frame_rev_observer
+	CTrack          unsafe.Pointer
 	CObserverHandle unsafe.Pointer
 }
+
 // _audio_encoded_frame_rev_observer
 // on_encoded_audio_frame_received
 func CAudioEncodedFrameObserver() *C.struct__audio_encoded_frame_rev_observer {
@@ -465,7 +534,7 @@ func createAudioEncodedFrameObserverItem(uid string, cTrack unsafe.Pointer, conn
 	// convert c type observer to handle for c api layer
 	cObserverHandle := C.agora_audio_encoded_frame_rev_observer_create(cObserver)
 	// end
-	
+
 	if cObserverHandle == nil {
 		return nil
 	}
@@ -473,11 +542,11 @@ func createAudioEncodedFrameObserverItem(uid string, cTrack unsafe.Pointer, conn
 	cPersistTrack := C.agora_create_remote_audio_track(cTrack)
 
 	item := &EncAudioFrameObserverItem{
-		Uid: uid,
-		Con: conn,
+		Uid:             uid,
+		Con:             conn,
 		CObserverHandle: cObserverHandle,
-		CObserver: cObserver,
-		CTrack: cPersistTrack,
+		CObserver:       cObserver,
+		CTrack:          cPersistTrack,
 	}
 	return item
 }
@@ -494,6 +563,6 @@ func freeAudioEncodedFrameObserverItem(item *EncAudioFrameObserverItem) int {
 	item.CObserverHandle = nil
 
 	item.Con = nil
-	
+
 	return 0
 }

--- a/go_sdk/rtc/video_observer.go
+++ b/go_sdk/rtc/video_observer.go
@@ -26,13 +26,24 @@ func goOnVideoFrame(cObserver unsafe.Pointer, channelId *C.char, uid *C.char, fr
 	if goUid == "0" {
 		return C.int(0)
 	}
-	
+
 	con := agoraService.getConFromHandle(cObserver, ConTypeCVideoObserver)
-	if con == nil || con.videoObserver == nil || con.videoObserver.OnFrame == nil {
+	if con == nil || con.videoObserver == nil {
+		return C.int(0)
+	}
+	if con.videoObserver.OnReusedFrame == nil && con.videoObserver.OnFrame == nil {
 		return C.int(0)
 	}
 	goChannelId := C.GoString(channelId)
-	
+
+	if con.videoObserver.OnReusedFrame != nil {
+		goFrame := GoVideoFrameReused(frame)
+		if con.videoObserver.OnReusedFrame(goChannelId, goUid, goFrame) {
+			return C.int(1)
+		}
+		return C.int(0)
+	}
+
 	goFrame := GoVideoFrame(frame)
 	ret := con.videoObserver.OnFrame(goChannelId, goUid, goFrame)
 	if ret {
@@ -49,11 +60,13 @@ func goOnEncodedVideoFrame(observer unsafe.Pointer, uid C.uint32_t, imageBuffer 
 		return C.int(0)
 	}
 	con := agoraService.getConFromHandle(observer, ConTypeCEncodedVideoObserver)
-	if con == nil || con.encodedVideoObserver == nil || con.encodedVideoObserver.OnEncodedVideoFrame == nil {
+	if con == nil || con.encodedVideoObserver == nil {
+		return C.int(0)
+	}
+	if con.encodedVideoObserver.OnReusedEncodedVideoFrame == nil && con.encodedVideoObserver.OnEncodedVideoFrame == nil {
 		return C.int(0)
 	}
 	goUid := strconv.FormatUint(uint64(uid), 10)
-	goImageBuffer := C.GoBytes(unsafe.Pointer(imageBuffer), C.int(length))
 	// GoEncodedVideoFrameInfo(video_encoded_frame_info)
 	goFrameInfo := &EncodedVideoFrameInfo{
 		CodecType:       VideoCodecType(video_encoded_frame_info.codec_type),
@@ -69,6 +82,14 @@ func goOnEncodedVideoFrame(observer unsafe.Pointer, uid C.uint32_t, imageBuffer 
 		StreamType:      int(video_encoded_frame_info.stream_type),
 		PresentTimeMs:   int64(video_encoded_frame_info.presentation_ms),
 	}
+	if con.encodedVideoObserver.OnReusedEncodedVideoFrame != nil {
+		goImageBuffer := cUint8SliceFromSize(imageBuffer, length)
+		if con.encodedVideoObserver.OnReusedEncodedVideoFrame(goUid, goImageBuffer, goFrameInfo) {
+			return C.int(1)
+		}
+		return C.int(0)
+	}
+	goImageBuffer := C.GoBytes(unsafe.Pointer(imageBuffer), C.int(length))
 	if con.encodedVideoObserver.OnEncodedVideoFrame(goUid, goImageBuffer, goFrameInfo) {
 		return C.int(1)
 	}


### PR DESCRIPTION
## Summary

This PR adds opt-in reused observer callbacks for RTC raw video, encoded video, and selected
audio frame callbacks.

The goal is to reduce per-frame allocations in high-frequency observer paths. The existing
observer callbacks keep their current copy-based behavior. The new callbacks expose SDK-owned
buffers through `unsafe.Slice` and let callers decide when and how to copy into their own
memory.

## What Changed

### New observer callbacks

- `VideoFrameObserver.OnReusedFrame`
- `VideoEncodedFrameObserver.OnReusedEncodedVideoFrame`
- `AudioFrameObserver.OnReusedRecordAudioFrame`
- `AudioFrameObserver.OnReusedPlaybackAudioFrame`
- `AudioFrameObserver.OnReusedMixedAudioFrame`
- `AudioFrameObserver.OnReusedEarMonitoringAudioFrame`

### Callback behavior

- Existing callbacks are unchanged and still return copied Go-owned buffers.
- New reused callbacks expose temporary zero-copy views of SDK-owned buffers.
- Reused callbacks are prioritized when both reused and legacy callbacks are set.
- `OnPlaybackAudioFrameBeforeMixing` is intentionally unchanged.

### Examples

Added dedicated examples for the new APIs:

- `go_sdk/examples/send_recv_yuv_reused`
- `go_sdk/examples/recv_h264_reused`
- `go_sdk/examples/recv_pcm_reused`

These examples demonstrate the intended usage pattern:
copy inside the callback if the data must outlive the callback.

## API Contract

The reused callbacks expose SDK-owned memory and therefore have stricter lifetime rules:

- the frame buffer is only valid during the callback
- callers must copy the data inside the callback before storing it or passing it to another
goroutine
- buffers must be treated as read-only

This keeps the zero-copy optimization isolated to explicit opt-in APIs without changing the
safety guarantees of the existing callbacks.

## Compatibility

This change is backward compatible.

- Existing callback names and behavior are preserved.
- Existing applications do not need to change anything.
- Only applications that explicitly adopt `OnReused...` callbacks opt into the new memory
contract.