### PR TITLE
FEAT: add connection-level remote audio track APM config for 2.4.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,92 @@ con.PushVideoFrame(frame)
 ```
 
 ---
+
+## 2026.07.13 Release Version 2.4.16
+
+### New Features
+
+- **Connection-level Remote Audio APM Configuration**  
+  Supports controlling the APM (`audio_processing_remote_playback`) for remote audio tracks on a per-`RtcConnection` basis, no longer relying solely on the global Service-level configuration.
+
+- **New API**  
+  `RtcConnection.SetRemoteAudioTrackAPMModel(model, config)`:
+  - **If not called:** The Connection inherits `AgoraServiceConfig.APMModel` / `APMConfig` at creation (compatible with previous Service-level behavior).
+  - **If called:** The Connection’s own setting takes precedence, overriding the Service-level APM settings.
+  - **Must be called before `Connect()`.**
+  - `model` description: `ApmModeOn` (1) to enable, `ApmModeOff` (0) to disable.
+  - `config` description: Required when `model=1`, must be `nil` when `model=0`.
+  - Return value: 0 for success, -2000 for invalid parameters, -2002 if enabling with a nil config.
+
+- **New APM Mode Constants** (see `common_consts.go`):
+  ```go
+  ApmModeInherit = -1
+  ApmModeOff = 0
+  ApmModeOn = 1
+  ```
+
+- **Unit Tests**  
+  Added `go_sdk/rtc/remote_audio_track_apm_test.go`, covering Service inheritance, Connection override, parameter validation, and `isEnable3A()` edge logic.
+
+### Improvements
+
+- The logic of `isEnable3A()` / `setApmFilterProperties()` has been modified to read the Connection-level `remoteAudioTrackAPMModel` / `remoteAudioTrackAPMConfig`, no longer directly reading `agoraService.apmConfig`.
+- The default `APMModel` in `NewAgoraServiceConfig()` has been changed from the literal `0` to `ApmModeOff` for improved clarity.
+
+### Backward Compatibility
+
+- The Service-level `APMModel` / `APMConfig` remain unchanged; existing code that sets `svcCfg.APMModel = 1` during `Initialize()` does not need modification.
+- Under a single Service, some Connections can inherit the Service configuration while others can independently enable/disable APM using `SetRemoteAudioTrackAPMModel`.
+
+### Usage Examples
+
+#### Scenario 1: Only a Specific Connection Enables APM (Recommended New Way)
+
+```go
+svcCfg := agoraservice.NewAgoraServiceConfig()
+svcCfg.AppId = appid
+agoraservice.Initialize(svcCfg) // Do not set APMModel on Service
+conCfg := agoraservice.NewRtcConnectionConfig()
+con := agoraservice.NewRtcConnection(conCfg, pubCfg)
+con.SetRemoteAudioTrackAPMModel(agoraservice.ApmModeOn, agoraservice.NewAPMConfig())
+con.Connect(token, channel, uid)
+```
+
+#### Scenario 2: Backward Compatibility (Enable APM Globally via Service)
+
+```go
+svcCfg.APMModel = agoraservice.ApmModeOn
+svcCfg.APMConfig = agoraservice.NewAPMConfig()
+agoraservice.Initialize(svcCfg)
+con := agoraservice.NewRtcConnection(conCfg, pubCfg) // Automatically inherits Service settings
+con.Connect(token, channel, uid)
+```
+
+#### Scenario 3: Service-level APM Enabled, Explicitly Disabled for One Connection
+
+```go
+svcCfg.APMModel = agoraservice.ApmModeOn
+svcCfg.APMConfig = agoraservice.NewAPMConfig()
+agoraservice.Initialize(svcCfg)
+con := agoraservice.NewRtcConnection(conCfg, pubCfg)
+con.SetRemoteAudioTrackAPMModel(agoraservice.ApmModeOff, nil)
+con.Connect(token, channel, uid)
+```
+
+### Unit Tests
+
+```shell
+cd go_sdk/rtc
+CGO_ENABLED=1 go test -vet=off -v -run 'TestInheritServiceAPM|TestSetRemoteAudioTrackAPMModel|TestIsEnable3A' .
+```
+
+### Notes
+
+- This change only affects the APM of remote audio tracks; `ExternalAudioProcessor` (local PCM source) still depends on the Service-level `APMModel` and is not controlled by this Connection-level setting.
+- `SetRemoteAudioTrackAPMModel` must be called before `Connect()`. Calling it after `Connect` will not affect tracks that are already subscribed.
+
+
+
 ## 2026.07.06 Release Version 2.4.15
 - **Bug Fix**: Fixed an issue where `joinUserList`/`leaveUserList`/`timeoutUserList` in RTM `PresenceEvent` interval mode were not properly converted.
 - **Bug Fix**: Fixed an issue where `OnWhoNowResult`/`OnGetOnlineUsersResult` only returned the first user; now these return the complete user list.

--- a/README.zh.md
+++ b/README.zh.md
@@ -281,6 +281,95 @@ todo：
 1、增加get sid
 2、增加自编码流双流模式的sample和验证
 
+How to run ut test:
+// for whole project:
+cd go_sdk/rtc
+CGO_ENABLED=1 go test -vet=off -v .
+
+## 2026.07.13 发布 2.4.16 版本
+
+### 新增
+
+- **Connection 级远端音频 APM 配置**  
+  支持按 `RtcConnection` 单独控制远端音频轨道的 APM（`audio_processing_remote_playback`），不再仅依赖 Service 层的全局配置。
+
+- **新增 API**  
+  `RtcConnection.SetRemoteAudioTrackAPMModel(model, config)`：
+  - **未调用时**：Connection 在创建时继承 `AgoraServiceConfig.APMModel` / `APMConfig`（与原有 Service 级配置行为兼容）。
+  - **调用后**：优先以 Connection 配置为准，忽略 Service 级 APM 设置。
+  - **须在 `Connect()` 之前调用。**
+  - `model` 说明：`ApmModeOn` (1) 开启，`ApmModeOff` (0) 关闭。
+  - `config` 说明：`model=1` 时必填，`model=0` 时请传 `nil`。
+  - 返回值：0 成功，-2000 参数无效，-2002 开启时 config 为空。
+
+- **新增 APM 模式常量**（见 `common_consts.go`）：
+  ```go
+  ApmModeInherit = -1
+  ApmModeOff = 0
+  ApmModeOn = 1
+  ```
+
+- **单元测试**  
+  新增 `go_sdk/rtc/remote_audio_track_apm_test.go`，覆盖 Service 继承、Connection 覆盖、参数校验及 `isEnable3A()` 边界逻辑。
+
+### 优化
+
+- `isEnable3A()` / `setApmFilterProperties()` 逻辑调整为读取 Connection 级 `remoteAudioTrackAPMModel` / `remoteAudioTrackAPMConfig`，不再直接读取 `agoraService.apmConfig`。
+- `NewAgoraServiceConfig()` 默认 `APMModel` 由字面量 0 改为 `ApmModeOff`，语义更清晰。
+
+### 向后兼容
+
+- Service 级 `APMModel` / `APMConfig` 保持不变；已有在 `Initialize()` 时设置 `svcCfg.APMModel = 1` 的代码无需修改。
+- 同一 Service 下可混用部分 Connection 继承 Service 配置，部分通过 `SetRemoteAudioTrackAPMModel` 单独控制开启/关闭 APM。
+
+### 使用示例
+
+#### 场景 1：仅某个 Connection 启用 APM（推荐新方式）
+
+```go
+svcCfg := agoraservice.NewAgoraServiceConfig()
+svcCfg.AppId = appid
+agoraservice.Initialize(svcCfg) // Service 不设置 APMModel
+conCfg := agoraservice.NewRtcConnectionConfig()
+con := agoraservice.NewRtcConnection(conCfg, pubCfg)
+con.SetRemoteAudioTrackAPMModel(agoraservice.ApmModeOn, agoraservice.NewAPMConfig())
+con.Connect(token, channel, uid)
+```
+
+#### 场景 2：向后兼容（Service 全局启用）
+
+```go
+svcCfg.APMModel = agoraservice.ApmModeOn
+svcCfg.APMConfig = agoraservice.NewAPMConfig()
+agoraservice.Initialize(svcCfg)
+con := agoraservice.NewRtcConnection(conCfg, pubCfg) // 自动继承 Service 配置
+con.Connect(token, channel, uid)
+```
+
+#### 场景 3：Service 开启，单个 Connection 显式关闭
+
+```go
+svcCfg.APMModel = agoraservice.ApmModeOn
+svcCfg.APMConfig = agoraservice.NewAPMConfig()
+agoraservice.Initialize(svcCfg)
+con := agoraservice.NewRtcConnection(conCfg, pubCfg)
+con.SetRemoteAudioTrackAPMModel(agoraservice.ApmModeOff, nil)
+con.Connect(token, channel, uid)
+```
+
+### 单元测试
+
+```shell
+cd go_sdk/rtc
+CGO_ENABLED=1 go test -vet=off -v -run 'TestInheritServiceAPM|TestSetRemoteAudioTrackAPMModel|TestIsEnable3A' .
+```
+
+### 说明
+
+- 本次变更仅影响远端音频轨道 APM（Remote Audio Track）；`ExternalAudioProcessor`（本地 PCM 源）仍依赖 Service 级 `APMModel`，不受该 Connection 级控制。
+- `SetRemoteAudioTrackAPMModel` 必须在 `Connect()` 前调用，`Connect` 后调用不会影响已订阅的远端 track。
+
+
 ## 2026.07.06 发布 2.4.15 版本
 - **问题修复**：修复 RTM `PresenceEvent` interval 模式下 `joinUserList`/`leaveUserList`/`timeoutUserList` 未转换的问题。
 - **问题修复**：修复 `OnWhoNowResult`/`OnGetOnlineUsersResult` 仅返回首个用户的问题，现正确返回完整用户列表。

--- a/go_sdk/rtc/agora_service.go
+++ b/go_sdk/rtc/agora_service.go
@@ -168,7 +168,7 @@ func NewAgoraServiceConfig() *AgoraServiceConfig {
 		EnableSteroEncodeMode: 0, // default to 0,i.e default to mono encode mode
 		ConfigDir: "",   // format like: "./agora_rtc_log"
 		DataDir: "",     // format like: "./agora_rtc_log", should ensure the directory exists
-		APMModel: 0,
+		APMModel: ApmModeOff,
 		APMConfig: nil,
 		IdleMode: true, // default to true for  idle mode
 	}

--- a/go_sdk/rtc/common_consts.go
+++ b/go_sdk/rtc/common_consts.go
@@ -59,3 +59,10 @@ const (
 	 */
 	UserMediaInfoEnableLocalVideo UserMediaInfo = 8
 )
+// date 20260713, for apm filter related config
+// ApmMode 枚举
+const (
+    ApmModeInherit = -1   // 继承 Service 默认
+    ApmModeOff     = 0    // 关闭 APM
+    ApmModeOn      = 1    // 开启 APM
+)

--- a/go_sdk/rtc/remote_audio_track_apm_test.go
+++ b/go_sdk/rtc/remote_audio_track_apm_test.go
@@ -1,0 +1,298 @@
+/**
+ * author: Wei Hongqi
+ * date: 2026-07-13
+ * how to run:
+ cd go_sdk/rtc
+CGO_ENABLED=1 go test -vet=off -v -run 'RemoteAudioTrackAPM|InheritServiceAPM|SetRemoteAudioTrackAPMModel|IsEnable3A' .
+
+// whole file:
+cd go_sdk/rtc
+CGO_ENABLED=1 go test -vet=off -v -run 'RemoteAudioTrackAPM|InheritServiceAPM|SetRemoteAudioTrackAPMModel|IsEnable3A' .
+*/
+
+package agoraservice
+
+import (
+	"testing"
+	"unsafe"
+)
+
+func distinctAPMConfig() *APMConfig {
+	cfg := NewAPMConfig()
+	cfg.EnableDump = true
+	return cfg
+}
+
+func newTestRtcConnectionForAPM() *RtcConnection {
+	dummy := unsafe.Pointer(uintptr(1))
+	return &RtcConnection{
+		cConnection: dummy,
+		localUser:   &LocalUser{cLocalUser: dummy},
+	}
+}
+
+// inheritServiceAPMToConnection mirrors NewRtcConnection APM initialization (rtc_connection.go L535-536).
+func inheritServiceAPMToConnection(conn *RtcConnection) {
+	conn.remoteAudioTrackAPMModel = agoraService.apmModel
+	conn.remoteAudioTrackAPMConfig = agoraService.apmConfig
+}
+
+func withServiceAPMState(t *testing.T, model int, config *APMConfig, fn func()) {
+	t.Helper()
+	oldModel := agoraService.apmModel
+	oldConfig := agoraService.apmConfig
+	agoraService.apmModel = model
+	agoraService.apmConfig = config
+	t.Cleanup(func() {
+		agoraService.apmModel = oldModel
+		agoraService.apmConfig = oldConfig
+	})
+	fn()
+}
+
+func TestInheritServiceAPM_WithoutSetter(t *testing.T) {
+	svcCfg := distinctAPMConfig()
+
+	cases := []struct {
+		name       string
+		svcModel   int
+		svcConfig  *APMConfig
+		wantModel  int
+		wantConfig *APMConfig
+		wantEnable bool
+	}{
+		{
+			name:       "service_off",
+			svcModel:   ApmModeOff,
+			svcConfig:  nil,
+			wantModel:  ApmModeOff,
+			wantConfig: nil,
+			wantEnable: false,
+		},
+		{
+			name:       "service_on_with_config",
+			svcModel:   ApmModeOn,
+			svcConfig:  svcCfg,
+			wantModel:  ApmModeOn,
+			wantConfig: svcCfg,
+			wantEnable: true,
+		},
+		{
+			name:       "service_on_nil_config",
+			svcModel:   ApmModeOn,
+			svcConfig:  nil,
+			wantModel:  ApmModeOn,
+			wantConfig: nil,
+			wantEnable: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			withServiceAPMState(t, tc.svcModel, tc.svcConfig, func() {
+				conn := newTestRtcConnectionForAPM()
+				inheritServiceAPMToConnection(conn)
+
+				if conn.remoteAudioTrackAPMModel != tc.wantModel {
+					t.Fatalf("remoteAudioTrackAPMModel=%d, want %d", conn.remoteAudioTrackAPMModel, tc.wantModel)
+				}
+				if conn.remoteAudioTrackAPMConfig != tc.wantConfig {
+					t.Fatalf("remoteAudioTrackAPMConfig=%p, want %p", conn.remoteAudioTrackAPMConfig, tc.wantConfig)
+				}
+				if got := conn.isEnable3A(); got != tc.wantEnable {
+					t.Fatalf("isEnable3A()=%v, want %v", got, tc.wantEnable)
+				}
+			})
+		})
+	}
+}
+
+func TestSetRemoteAudioTrackAPMModel_OverridesService(t *testing.T) {
+	svcCfg := distinctAPMConfig()
+	customCfg := NewAPMConfig()
+	customCfg.EnableDump = false
+
+	t.Run("override_off_when_service_on", func(t *testing.T) {
+		withServiceAPMState(t, ApmModeOn, svcCfg, func() {
+			conn := newTestRtcConnectionForAPM()
+			inheritServiceAPMToConnection(conn)
+
+			if ret := conn.SetRemoteAudioTrackAPMModel(ApmModeOff, nil); ret != 0 {
+				t.Fatalf("SetRemoteAudioTrackAPMModel()=%d, want 0", ret)
+			}
+			if conn.remoteAudioTrackAPMModel != ApmModeOff {
+				t.Fatalf("remoteAudioTrackAPMModel=%d, want %d", conn.remoteAudioTrackAPMModel, ApmModeOff)
+			}
+			if conn.remoteAudioTrackAPMConfig != nil {
+				t.Fatalf("remoteAudioTrackAPMConfig=%p, want nil", conn.remoteAudioTrackAPMConfig)
+			}
+			if conn.isEnable3A() {
+				t.Fatal("isEnable3A()=true, want false")
+			}
+		})
+	})
+
+	t.Run("override_on_when_service_off", func(t *testing.T) {
+		withServiceAPMState(t, ApmModeOff, nil, func() {
+			conn := newTestRtcConnectionForAPM()
+			inheritServiceAPMToConnection(conn)
+
+			if ret := conn.SetRemoteAudioTrackAPMModel(ApmModeOn, customCfg); ret != 0 {
+				t.Fatalf("SetRemoteAudioTrackAPMModel()=%d, want 0", ret)
+			}
+			if conn.remoteAudioTrackAPMModel != ApmModeOn {
+				t.Fatalf("remoteAudioTrackAPMModel=%d, want %d", conn.remoteAudioTrackAPMModel, ApmModeOn)
+			}
+			if conn.remoteAudioTrackAPMConfig != customCfg {
+				t.Fatalf("remoteAudioTrackAPMConfig=%p, want %p", conn.remoteAudioTrackAPMConfig, customCfg)
+			}
+			if !conn.isEnable3A() {
+				t.Fatal("isEnable3A()=false, want true")
+			}
+		})
+	})
+
+	t.Run("override_on_uses_custom_config_not_service", func(t *testing.T) {
+		withServiceAPMState(t, ApmModeOn, svcCfg, func() {
+			conn := newTestRtcConnectionForAPM()
+			inheritServiceAPMToConnection(conn)
+
+			if ret := conn.SetRemoteAudioTrackAPMModel(ApmModeOn, customCfg); ret != 0 {
+				t.Fatalf("SetRemoteAudioTrackAPMModel()=%d, want 0", ret)
+			}
+			if conn.remoteAudioTrackAPMConfig != customCfg {
+				t.Fatalf("remoteAudioTrackAPMConfig=%p, want %p", conn.remoteAudioTrackAPMConfig, customCfg)
+			}
+			if conn.remoteAudioTrackAPMConfig == svcCfg {
+				t.Fatal("remoteAudioTrackAPMConfig should not point to service config after override")
+			}
+		})
+	})
+
+	t.Run("service_change_after_override_does_not_affect_connection", func(t *testing.T) {
+		withServiceAPMState(t, ApmModeOff, nil, func() {
+			conn := newTestRtcConnectionForAPM()
+			inheritServiceAPMToConnection(conn)
+
+			if ret := conn.SetRemoteAudioTrackAPMModel(ApmModeOn, customCfg); ret != 0 {
+				t.Fatalf("SetRemoteAudioTrackAPMModel()=%d, want 0", ret)
+			}
+
+			agoraService.apmModel = ApmModeOff
+			agoraService.apmConfig = nil
+
+			if conn.remoteAudioTrackAPMModel != ApmModeOn {
+				t.Fatalf("remoteAudioTrackAPMModel=%d, want %d after service change", conn.remoteAudioTrackAPMModel, ApmModeOn)
+			}
+			if conn.remoteAudioTrackAPMConfig != customCfg {
+				t.Fatalf("remoteAudioTrackAPMConfig=%p, want %p after service change", conn.remoteAudioTrackAPMConfig, customCfg)
+			}
+			if !conn.isEnable3A() {
+				t.Fatal("isEnable3A()=false, want true after service change")
+			}
+		})
+	})
+}
+
+func TestSetRemoteAudioTrackAPMModel_Validation(t *testing.T) {
+	cfg := distinctAPMConfig()
+
+	t.Run("nil_connection", func(t *testing.T) {
+		if ret := (*RtcConnection)(nil).SetRemoteAudioTrackAPMModel(ApmModeOn, cfg); ret != -2000 {
+			t.Fatalf("SetRemoteAudioTrackAPMModel()=%d, want -2000", ret)
+		}
+	})
+
+	t.Run("on_without_config", func(t *testing.T) {
+		conn := newTestRtcConnectionForAPM()
+		if ret := conn.SetRemoteAudioTrackAPMModel(ApmModeOn, nil); ret != -2002 {
+			t.Fatalf("SetRemoteAudioTrackAPMModel()=%d, want -2002", ret)
+		}
+		if conn.remoteAudioTrackAPMModel != 0 {
+			t.Fatalf("remoteAudioTrackAPMModel=%d, want unchanged 0 after -2002", conn.remoteAudioTrackAPMModel)
+		}
+		if conn.remoteAudioTrackAPMConfig != nil {
+			t.Fatalf("remoteAudioTrackAPMConfig=%p, want unchanged nil after -2002", conn.remoteAudioTrackAPMConfig)
+		}
+	})
+
+	t.Run("off_clears_config", func(t *testing.T) {
+		conn := newTestRtcConnectionForAPM()
+		conn.remoteAudioTrackAPMModel = ApmModeOn
+		conn.remoteAudioTrackAPMConfig = cfg
+
+		if ret := conn.SetRemoteAudioTrackAPMModel(ApmModeOff, cfg); ret != 0 {
+			t.Fatalf("SetRemoteAudioTrackAPMModel()=%d, want 0", ret)
+		}
+		if conn.remoteAudioTrackAPMModel != ApmModeOff {
+			t.Fatalf("remoteAudioTrackAPMModel=%d, want %d", conn.remoteAudioTrackAPMModel, ApmModeOff)
+		}
+		if conn.remoteAudioTrackAPMConfig != nil {
+			t.Fatalf("remoteAudioTrackAPMConfig=%p, want nil", conn.remoteAudioTrackAPMConfig)
+		}
+	})
+
+	t.Run("on_with_config", func(t *testing.T) {
+		conn := newTestRtcConnectionForAPM()
+		if ret := conn.SetRemoteAudioTrackAPMModel(ApmModeOn, cfg); ret != 0 {
+			t.Fatalf("SetRemoteAudioTrackAPMModel()=%d, want 0", ret)
+		}
+		if conn.remoteAudioTrackAPMModel != ApmModeOn {
+			t.Fatalf("remoteAudioTrackAPMModel=%d, want %d", conn.remoteAudioTrackAPMModel, ApmModeOn)
+		}
+		if conn.remoteAudioTrackAPMConfig != cfg {
+			t.Fatalf("remoteAudioTrackAPMConfig=%p, want %p", conn.remoteAudioTrackAPMConfig, cfg)
+		}
+	})
+}
+
+func TestIsEnable3A_Boundary(t *testing.T) {
+	cfg := distinctAPMConfig()
+
+	cases := []struct {
+		name       string
+		model      int
+		config     *APMConfig
+		wantEnable bool
+	}{
+		{"off_nil_config", ApmModeOff, nil, false},
+		{"off_with_config", ApmModeOff, cfg, false},
+		{"on_nil_config", ApmModeOn, nil, false},
+		{"on_with_config", ApmModeOn, cfg, true},
+		{"inherit_with_config", ApmModeInherit, cfg, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			conn := newTestRtcConnectionForAPM()
+			conn.remoteAudioTrackAPMModel = tc.model
+			conn.remoteAudioTrackAPMConfig = tc.config
+
+			if got := conn.isEnable3A(); got != tc.wantEnable {
+				t.Fatalf("isEnable3A()=%v, want %v", got, tc.wantEnable)
+			}
+		})
+	}
+}
+
+func TestSetRemoteAudioTrackAPMModel_ApmModeInherit(t *testing.T) {
+	svcCfg := distinctAPMConfig()
+
+	withServiceAPMState(t, ApmModeOn, svcCfg, func() {
+		conn := newTestRtcConnectionForAPM()
+		inheritServiceAPMToConnection(conn)
+
+		if ret := conn.SetRemoteAudioTrackAPMModel(ApmModeInherit, nil); ret != 0 {
+			t.Fatalf("SetRemoteAudioTrackAPMModel()=%d, want 0", ret)
+		}
+		if conn.remoteAudioTrackAPMModel != ApmModeInherit {
+			t.Fatalf("remoteAudioTrackAPMModel=%d, want %d", conn.remoteAudioTrackAPMModel, ApmModeInherit)
+		}
+		if conn.remoteAudioTrackAPMConfig != nil {
+			t.Fatalf("remoteAudioTrackAPMConfig=%p, want nil", conn.remoteAudioTrackAPMConfig)
+		}
+		if conn.isEnable3A() {
+			t.Fatal("isEnable3A()=true, want false for ApmModeInherit")
+		}
+	})
+}

--- a/go_sdk/rtc/rtc_connection.go
+++ b/go_sdk/rtc/rtc_connection.go
@@ -461,6 +461,10 @@ type RtcConnection struct {
 
 	// for encoded audio frame observer
 	encodedAudioFrameObserver  *AudioEncodedFrameObserver
+
+	// date: 20260713, for apm filter for remoate audio track config, default to inherit from service config
+	remoteAudioTrackAPMModel int // -1: inherit from service config, 0: off, 1: on
+	remoteAudioTrackAPMConfig *APMConfig // nil: inherit from service config, not nil: use the config
 }
 
 // for pcm consumption stats
@@ -522,7 +526,14 @@ func NewRtcConnection(cfg *RtcConnectionConfig, publishConfig *RtcConnectionPubl
 		transcodingWorker:           nil,
 		videoEncoderConfiguration:   nil,
 		encodedAudioFrameObserver:   nil,
+		remoteAudioTrackAPMModel:    ApmModeInherit,
+		remoteAudioTrackAPMConfig:   nil,
 	}
+
+	// date: 20260713, for apm filter for remoate audio track config, default to inherit from service config
+	// for initializing the remote audio track apm model and config to inherit from service config
+	ret.remoteAudioTrackAPMModel = agoraService.apmModel
+	ret.remoteAudioTrackAPMConfig = agoraService.apmConfig
 
 	if isSupportExternalAudio(publishConfig) {
 		ret.sendExternalAudioParameters = &SendExternalAudioParameters{
@@ -1521,9 +1532,10 @@ func (conn *RtcConnection) isEnable3A() bool {
 	if conn == nil || conn.cConnection == nil || conn.localUser == nil || conn.localUser.cLocalUser == nil {
 		return false
 	}
-	if agoraService.apmConfig == nil {
+	if conn.remoteAudioTrackAPMModel < int(ApmModeOn) || conn.remoteAudioTrackAPMConfig == nil {
 		return false
 	}
+	
 	return true
 }
 func (conn *RtcConnection) setApmFilterProperties(uid *C.char, cRemoteAudioTrack unsafe.Pointer) int {
@@ -1543,7 +1555,7 @@ func (conn *RtcConnection) setApmFilterProperties(uid *C.char, cRemoteAudioTrack
 	}
 
 	// Set APM configuration
-	configJSON := agoraService.apmConfig.toJson()
+	configJSON := conn.remoteAudioTrackAPMConfig.toJson()
 	ret = setFilterPropertyByTrack(cRemoteAudioTrack, "audio_processing_remote_playback", "apm_config", configJSON, false)
 	if ret != 0 {
 		fmt.Printf("Failed to set apm_config, error: %d\n", ret)
@@ -1552,7 +1564,7 @@ func (conn *RtcConnection) setApmFilterProperties(uid *C.char, cRemoteAudioTrack
 	fmt.Println("*****APM config set:%s", configJSON)
 
 	// Enable dump
-	if agoraService.apmConfig.EnableDump {
+	if conn.remoteAudioTrackAPMConfig.EnableDump {
 		ret = setFilterPropertyByTrack(cRemoteAudioTrack, "audio_processing_remote_playback", "apm_dump", "true", false)
 		if ret != 0 {
 			fmt.Printf("Failed to enable apm_dump, error: %d\n", ret)
@@ -1856,4 +1868,42 @@ func (conn *RtcConnection) GetSid() string {
 	}
 	//note: do not free the c_sid, it is a const string
 	return C.GoString(c_sid)
+}
+
+// SetRemoteAudioTrackAPMModel configures APM processing for remote audio tracks on this connection.
+//
+// APM resolution rules:
+//   - If this method is NOT called, the connection uses the service-level APMModel and APMConfig
+//     set in AgoraServiceConfig during Initialize.
+//   - If this method IS called, the provided model and config take precedence for this connection,
+//     and the service-level APM settings are ignored.
+//
+// Must be called before RtcConnection.Connect.
+//
+// Parameters:
+//   - model: ApmModeOn (1) to enable APM, ApmModeOff (0) to disable APM.
+//   - config: APM algorithm configuration. Required when model is ApmModeOn; set to nil when
+//     model is ApmModeOff.
+//
+// Returns:
+//   - 0 on success, or a negative error code on failure.
+func (conn *RtcConnection) SetRemoteAudioTrackAPMModel(model int, config *APMConfig) int {
+	if conn == nil || conn.cConnection == nil || conn.localUser == nil || conn.localUser.cLocalUser == nil {
+		return -2000
+	}
+
+	// for apmModeOn, if config is nil, set the config to default config
+	// but never set the config to default, for we do not the what the real algorithmic config the customer wants to set
+
+	if model == int(ApmModeOn)  && config == nil {
+		return -2002
+	}
+	conn.remoteAudioTrackAPMModel = model
+	conn.remoteAudioTrackAPMConfig = config
+
+	if model < int(ApmModeOn)  {
+		conn.remoteAudioTrackAPMConfig = nil
+	}
+
+	return 0
 }


### PR DESCRIPTION
Support per-connection APM via SetRemoteAudioTrackAPMModel while keeping service-level settings as the default fallback, and add unit tests plus release notes.