### PR TITLE
FEAT: add InterruptAudioWithDelay for 2.4.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,13 @@ con.PushVideoFrame(frame)
 
 ---
 
+
+## 2026.08.03 Release Version 2.4.17
+
+### New Features
+- **New API**  
+  `RtcConnection.InterruptAudioWithDelay()`: Allows interrupting with an additional delay time, specified in milliseconds (default is 0, meaning immediate interruption). This is useful for situations where the remote app strictly relies on the OnMutedAudio/OnUnmutedAudio callbacks to handle business logic. Setting a delay can help prevent callback disorder on the remote app.
+
 ## 2026.07.13 Release Version 2.4.16
 
 ### New Features

--- a/README.zh.md
+++ b/README.zh.md
@@ -286,6 +286,13 @@ How to run ut test:
 cd go_sdk/rtc
 CGO_ENABLED=1 go test -vet=off -v .
 
+
+## 2026.08.03 发布 2.4.17 版本
+### 新增
+- **新增 API**  
+  `RtcConnection.InterruptAudioWithDelay()`：允许打断的时候，增加一个延迟时间，单位是毫秒，默认是0，即立即打断。用在远端app非常严格依赖OnMutedAudio/OnUnmutedAudio回调来处理业务的场景，可以设置一个延迟，避免远端app的回调混乱。
+
+
 ## 2026.07.13 发布 2.4.16 版本
 
 ### 新增

--- a/go_sdk/rtc/rtc_connection.go
+++ b/go_sdk/rtc/rtc_connection.go
@@ -1907,3 +1907,42 @@ func (conn *RtcConnection) SetRemoteAudioTrackAPMModel(model int, config *APMCon
 
 	return 0
 }
+
+//
+// InterruptAudioWithDelay interrupts the audio track with a delay
+// delayMs: the delay time in milliseconds, the range is 0-20, default is 5
+// return: 0 on success, or a negative error code on failure
+func (conn *RtcConnection) InterruptAudioWithDelay(delayMs int) int {
+	if conn == nil || conn.cConnection == nil || conn.audioTrack == nil {
+		return -2000
+	}
+
+	//check delayMs is valid
+	if delayMs < 0 {
+		delayMs = 0
+	}
+	if delayMs > 20 {
+		delayMs = 20
+	}
+
+	if conn.audioScenario == AudioScenarioAiServer {
+		// for aiServer, we need to unpublish the track
+		conn.UnpublishAudio()
+		// sleep the delayMs
+		if delayMs > 0 {
+			time.Sleep(time.Duration(delayMs) * time.Millisecond)
+		}
+		// and publish the track again
+		conn.PublishAudio()
+
+	} else {
+		// and other scenarios, we need to clear the buffer of the track
+		conn.audioTrack.ClearSenderBuffer()
+	}
+
+	// if has audio consumption, we need to reset the stats
+	if conn.pcmConsumeStats != nil {
+		conn.pcmConsumeStats.reset()
+	}
+	return 0
+}


### PR DESCRIPTION
Allow a short delay between UnpublishAudio and PublishAudio so remote OnMuted/OnUnmuted callbacks stay ordered.